### PR TITLE
fix: pass unit timezone to Envelope instance

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -60,8 +60,6 @@ class DefaultController extends AbstractController
         AtendimentoServiceInterface $atendimentoService,
         ChartService $chartService,
     ): Response {
-        $envelope = new Envelope();
-
         $data = new GenerateChartDto();
         $form = $this
             ->createForm(ChartType::class, $data)
@@ -105,10 +103,10 @@ class DefaultController extends AbstractController
                 break;
         }
 
-        $data = $data->chart->jsonSerialize();
-        $envelope->setData($data);
-
-        return $this->json($envelope);
+        return $this->json(new Envelope(
+            timezone: $unidade->getDateTimeZone(),
+            data: $data->chart->jsonSerialize(),
+        ));
     }
 
     #[Route("/report", name: "report", methods: ['GET'])]


### PR DESCRIPTION
## Summary

- Pass `$unidade->getDateTimeZone()` to the `Envelope` constructor in the chart action so the frontend receives the correct local timestamp and timezone name (`tz`) in the JSON response

## Test plan

- [x] Verify the chart endpoint returns the correct `tz` and `time` fields in the unit's configured timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)