### PR TITLE
chore: upgrade Symfony from 7.1 to 7.4 LTS (#455)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,19 +3,23 @@
     "license": "MIT",
     "type": "symfony-bundle",
     "autoload": {
-        "psr-4": { "Novosga\\ReportsBundle\\": "src/" }
+        "psr-4": {
+            "Novosga\\ReportsBundle\\": "src/"
+        }
     },
     "autoload-dev": {
-        "psr-4": { "Novosga\\ReportsBundle\\Tests\\": "tests/" }
+        "psr-4": {
+            "Novosga\\ReportsBundle\\Tests\\": "tests/"
+        }
     },
     "require": {
         "php": ">=8.2",
         "doctrine/orm": "^3.2",
         "novosga/core": "2.3.x-dev",
-        "symfony/framework-bundle": "7.1.*",
-        "symfony/form": "7.1.*",
+        "symfony/framework-bundle": "7.4.*",
+        "symfony/form": "7.4.*",
         "twig/twig": "^2.12|^3.0",
-        "symfony/translation": "7.1.*"
+        "symfony/translation": "7.4.*"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",


### PR DESCRIPTION
## Summary

Part of novosga/novosga#455 — main PR: novosga/novosga#495.

Bumps all `symfony/*` constraints from `7.1.*` → `7.4.*` in `composer.json`.

## Test plan

- [x] `composer install` resolves cleanly
- [x] `vendor/bin/phpunit` passes
- [x] `vendor/bin/phpstan` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)